### PR TITLE
Update timm requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository contains Jupyter notebooks for creating and preparing LoRA datas
 - A CUDA-enabled GPU with the appropriate drivers
 - `aria2` and `python3.10-venv` system packages (Ubuntu example below)
 - Python packages listed in `requirements.txt`
+- If running on Python 3.11 or newer, ensure `timm` is at least version 0.9.2 to
+  avoid dataclass initialization errors
 
 Install the system dependencies (Ubuntu/Debian example):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ torch
 onnx
 onnxruntime-gpu==1.20.1
 fairscale==0.4.13
-timm==0.6.12
+# Updated to avoid dataclass errors with Python 3.11+
+timm==0.9.2


### PR DESCRIPTION
## Summary
- bump `timm` to 0.9.2 in requirements to fix dataclass error on Python 3.11
- note the new minimum `timm` version in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849911802e48333bc429aadc776de7c